### PR TITLE
Upgrade arduino-pico core to version 2.5.2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ arduino-cli lib install "Etherkit Si5351" &> /dev/null
 
 # Patch toolchain (hacky)
 cpath=`pwd`
-ver="2.4.1"
+ver="2.5.2"
 cd "ADX FIRMWARE/EXPERIMENTAL/patches"
 cp Serial* ~/.arduino15/packages/rp2040/hardware/rp2040/$ver/cores/rp2040/
 cp cdc* ~/.arduino15/packages/rp2040/hardware/rp2040/$ver/pico-sdk/lib/tinyusb/src/class/cdc/


### PR DESCRIPTION
This PR upgrade the arduino-pico core to version 2.5.2. We use this core to build the firmware automatically using GitHub Actions.